### PR TITLE
feat: add "Everblush Lavender" theme

### DIFF
--- a/extension/js/globals.js
+++ b/extension/js/globals.js
@@ -351,6 +351,23 @@ const defaultOptions = {
         },
         {
           "version": "1.0.0",
+          "name": "Everblush Lavender",
+          "id": "8a7c3e5f2d1b4a9e6c8f0d2a4b6e8c0a:D",
+          "immortal": true,
+          "colorScheme": "dark",
+          "colors": {
+            "background": "#141b1e",
+            "textPrimary": "#b3b9b8",
+            "textSecondary": "#dadada",
+            "key": "#67b0e8",
+            "numberValue": "#e5c76b",
+            "booleanValue": "#bc90df",
+            "stringValue": "#8ccf7e",
+            "icons": "#e57474"
+          }
+        },
+        {
+          "version": "1.0.0",
           "name": "Gruvbox Dark",
           "id": "791f72e3ffbd4b14b2bd8f2bd6dff649:D",
           "immortal": true,


### PR DESCRIPTION
Hello 😊

Thanks for your very useful extension! I invite you to integrate this new theme:

<img width="493" height="378" alt="Everblush Lavender Theme - JSON Formatter" src="https://github.com/user-attachments/assets/1cf14325-0d83-4d9c-bc1b-038c67b8458e" />

Its colors are based on those of the [Everblush](https://github.com/Everblush/everblush) theme.

The focus is on familiarity with JSON keys in blue like the default VS Code theme, accessibility with red arrow icons, and readability with distinct colors for each JSON type.
